### PR TITLE
[ACI-148] Enable build cache in project automatically

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -15,6 +15,10 @@ workflows:
         is_skippable: false
         inputs:
         - verbose: "true"
+    - script:
+        title: Print Gradle init script
+        inputs:
+        - content: cat ~/.gradle/init.gradle
     - change-workdir:
         title: Switch working dir to _tmp
         inputs:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -15,10 +15,6 @@ workflows:
         is_skippable: false
         inputs:
         - verbose: "true"
-    - script:
-        title: Print Gradle init script
-        inputs:
-        - content: echo $BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN > $BITRISE_DEPLOY_DIR/token.txt
     - change-workdir:
         title: Switch working dir to _tmp
         inputs:
@@ -27,7 +23,6 @@ workflows:
         inputs:
         - module: app
         - variant: debug
-        - arguments: --build-cache
   _setup:
     steps:
     - script:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -18,7 +18,7 @@ workflows:
     - script:
         title: Print Gradle init script
         inputs:
-        - content: cat ~/.gradle/init.gradle
+        - content: echo $BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN > $BITRISE_DEPLOY_DIR/token.txt
     - change-workdir:
         title: Switch working dir to _tmp
         inputs:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -23,6 +23,7 @@ workflows:
         inputs:
         - module: app
         - variant: debug
+        - arguments: --build-cache
   _setup:
     steps:
     - script:

--- a/step/step.go
+++ b/step/step.go
@@ -62,7 +62,7 @@ func (step RemoteCacheStep) Run() error {
 		return fmt.Errorf("failed to set up remote caching: %w", err)
 	}
 	if err := step.addGlobalGradleProperties(); err != nil {
-		return fmt.Errorf("failed to apply additional Gradle properties")
+		return fmt.Errorf("failed to apply additional Gradle properties: %w", err)
 	}
 	step.logger.Donef("Init script added, remote cache enabled for subsequent builds")
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [X] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [X] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

[Build caching](https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties) is disabled by default in Gradle projects. If this is disabled, applying the remote cache setting doesn't have any effect. We need to enable build caching manually in this step.

### Changes

Enable build caching by placing a `gradle.properties` file in the Gradle home folder, which is applied automatically to every Gradle invocation.

### Investigation details

Gradle property resolution order: https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties

### Decisions

<!-- Please list decisions that were made for this change. -->
