### PR TITLE
Make push true by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Activates Bitrise Remote Build Cache for subsequent Gradle builds in the workflo
 
 This Step activates Bitrise's remote build cache for subsequent Gradle executions in the workflow.
 
-After this Step executes, Gradle builds will automatically read from the remote cache and push new entries if it's enabled. 
+After this Step executes, Gradle builds will automatically read from the remote cache and push new entries if it's enabled.
 
 </details>
 
@@ -26,7 +26,7 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 
 | Key | Description | Flags | Default |
 | --- | --- | --- | --- |
-| `push` | Whether the build can not only read, but write new entries to the remote cache | required | `false` |
+| `push` | Whether the build can not only read, but write new entries to the remote cache | required | `true` |
 | `verbose` | Enable logging additional information for troubleshooting | required | `false` |
 </details>
 

--- a/step.yml
+++ b/step.yml
@@ -20,7 +20,7 @@ toolkit:
     package_name: github.com/bitrise-steplib/bitrise-step-activate-gradle-remote-cache
 
 inputs:
-- push: "false"
+- push: "true"
   opts:
     title: Push new cache entries
     summary: Whether the build can not only read, but write new entries to the remote cache


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires NO [version update](https://semver.org/)

### Context

Per @zachgrayio's comment, it makes more sense to enable read-write cache in CI builds (unlike local builds).

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

Make the input true by default

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
