### PR TITLE
Update README with new default value for collect_metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 | --- | --- | --- | --- |
 | `push` | Whether the build can not only read, but write new entries to the remote cache | required | `true` |
 | `validation_level` | Level of cache entry validation for both uploads and downloads.  Levels: - `none`: no validation. - `warning`: print a warning about invalid cache entries, but don't interrupt the build - `error`: print an error about invalid cache entries and interrupt the build | required | `warning` |
-| `collect_metrics` | When enabled, this sets up Gradle build metrics collection for the subsequent Gradle invocations in the workflow. Metrics are sent to [Bitrise Insights](https://app.bitrise.io/insights). | required | `true` |
+| `collect_metrics` | When enabled, this sets up Gradle build metrics collection for the subsequent Gradle invocations in the workflow. Metrics are sent to [Bitrise Insights](https://app.bitrise.io/insights). | required | `false` |
 | `verbose` | Enable logging additional information for troubleshooting | required | `false` |
 </details>
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
❓  Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/) ❓  

Version change not needed afaik.

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Will close https://github.com/bitrise-steplib/bitrise-step-activate-gradle-remote-cache/issues/21

In 1.1.1 at https://github.com/bitrise-steplib/bitrise-step-activate-gradle-remote-cache/releases/tag/1.1.1
The default input value for `collect_metrics` was set to false.

> "collect_metrics" input set to "false" by default. We saw performance issues when this option was enabled, and we're working on the fix, but in the meantime we're changing the default to "false" to prevent unexpected build time degradation.

PR https://github.com/bitrise-steplib/bitrise-step-activate-gradle-remote-cache/pull/20 missed the update of the README.

While trialing the feature, we noticed that the Bitrise logs were saying the metric were disabled, while the README said that it was on by default.


<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

No Github Issue raised.

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

Update the default value of `collect_metrics` input value to `false` in the README

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

N/A

### Decisions

<!-- Please list decisions that were made for this change. -->

N/A