### PR TITLE
Check if the workspace has an active Bitrise Build Cache trial or subscription

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -exo pipefail
+set -eo pipefail
 
 UNAVAILABLE_MESSAGE=$(cat <<-END
 Bitrise Build Cache is not activated in this build.
@@ -15,13 +15,16 @@ END
 
 if [ "$BITRISEIO_BUILD_CACHE_ENABLED" != "true" ]; then
   printf "\n%s\n" "$UNAVAILABLE_MESSAGE"
+  set -x
   bitrise plugin install https://github.com/bitrise-io/bitrise-plugins-annotations.git
   bitrise :annotations annotate "$UNAVAILABLE_MESSAGE" --style error || {
     echo "Failed to create annotation"
-    exit 0
+    exit 1
   }
-  exit 0
+  exit 1
 fi
+
+set -x
 
 # download the Bitrise Build Cache CLI
 export BITRISE_BUILD_CACHE_CLI_VERSION="v0.8.0"

--- a/step.sh
+++ b/step.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+set -exo pipefail
 
 UNAVAILABLE_MESSAGE=$(cat <<-END
 Bitrise Build Cache is not activated in this build.

--- a/step.sh
+++ b/step.sh
@@ -14,6 +14,7 @@ EOF_MSG
 
 set -eo pipefail
 
+echo "Checking whether Bitrise Build Cache is activated for this workspace ..."
 if [ "$BITRISEIO_BUILD_CACHE_ENABLED" != "true" ]; then
   printf "\n%s\n" "$UNAVAILABLE_MESSAGE"
   set -x
@@ -24,6 +25,7 @@ if [ "$BITRISEIO_BUILD_CACHE_ENABLED" != "true" ]; then
   }
   exit 2
 fi
+echo "Bitrise Build Cache is activated in this workspace, configuring the build environment ..."
 
 set -x
 

--- a/step.sh
+++ b/step.sh
@@ -1,6 +1,28 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
+UNAVAILABLE_MESSAGE=$(cat <<-END
+Bitrise Build Cache is not activated in this build.
+
+You have added the **Activate Bitrise Build Cache for Gradle** add-on step to your workflow.
+
+However, you don't have an activate Bitrise Build Cache Trial or Subscription for the current workspace yet.
+
+You can activate a Trial at [app.bitrise.io/build-cache](https://app.bitrise.io/build-cache),
+or contact us at [support@bitrise.io](mailto:support@bitrise.io) to activate it.
+END
+)
+
+if [ "$BITRISEIO_BUILD_CACHE_ENABLED" != "true" ]; then
+  printf "\n%s\n" "$UNAVAILABLE_MESSAGE"
+  bitrise plugin install https://github.com/bitrise-io/bitrise-plugins-annotations.git
+  bitrise :annotations annotate "$UNAVAILABLE_MESSAGE" --style error || {
+    echo "Failed to create annotation"
+    exit 0
+  }
+  exit 0
+fi
+
 # download the Bitrise Build Cache CLI
 export BITRISE_BUILD_CACHE_CLI_VERSION="v0.8.0"
 curl --retry 5 -sSfL 'https://raw.githubusercontent.com/bitrise-io/bitrise-build-cache-cli/main/install/installer.sh' | sh -s -- -b /tmp/bin -d $BITRISE_BUILD_CACHE_CLI_VERSION

--- a/step.sh
+++ b/step.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-set -eo pipefail
 
-UNAVAILABLE_MESSAGE=$(cat <<-END
+# 'read' has to be before 'set -e'
+read -r -d '' UNAVAILABLE_MESSAGE << EOF_MSG
 Bitrise Build Cache is not activated in this build.
 
 You have added the **Activate Bitrise Build Cache for Gradle** add-on step to your workflow.
@@ -10,8 +10,9 @@ However, you don't have an activate Bitrise Build Cache Trial or Subscription fo
 
 You can activate a Trial at [app.bitrise.io/build-cache](https://app.bitrise.io/build-cache),
 or contact us at [support@bitrise.io](mailto:support@bitrise.io) to activate it.
-END
-)
+EOF_MSG
+
+set -eo pipefail
 
 if [ "$BITRISEIO_BUILD_CACHE_ENABLED" != "true" ]; then
   printf "\n%s\n" "$UNAVAILABLE_MESSAGE"
@@ -19,9 +20,9 @@ if [ "$BITRISEIO_BUILD_CACHE_ENABLED" != "true" ]; then
   bitrise plugin install https://github.com/bitrise-io/bitrise-plugins-annotations.git
   bitrise :annotations annotate "$UNAVAILABLE_MESSAGE" --style error || {
     echo "Failed to create annotation"
-    exit 1
+    exit 3
   }
-  exit 1
+  exit 2
 fi
 
 set -x


### PR DESCRIPTION
Print error and add annotation if the workspace doesn't have an active build cache trial or subscription, with
instructions how to activate a trial or contact us.
