### PR TITLE
chore: Bump CLI

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -30,7 +30,7 @@ echo "Bitrise Build Cache is activated in this workspace, configuring the build 
 set -x
 
 # download the Bitrise Build Cache CLI
-export BITRISE_BUILD_CACHE_CLI_VERSION="v0.14.1"
+export BITRISE_BUILD_CACHE_CLI_VERSION="v0.14.2"
 curl --retry 5 -sSfL 'https://raw.githubusercontent.com/bitrise-io/bitrise-build-cache-cli/main/install/installer.sh' | sh -s -- -b /tmp/bin -d $BITRISE_BUILD_CACHE_CLI_VERSION
 
 if [ "$collect_metrics" != "true" ] && [ "$collect_metrics" != "false" ]; then


### PR DESCRIPTION
Use latest CLI and Gradle analytics that improves cache hit rate calculation