### PR TITLE
Bump CLI version to v0.15.3

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -30,7 +30,7 @@ echo "Bitrise Build Cache is activated in this workspace, configuring the build 
 set -x
 
 # download the Bitrise Build Cache CLI
-export BITRISE_BUILD_CACHE_CLI_VERSION="v0.15.2"
+export BITRISE_BUILD_CACHE_CLI_VERSION="v0.15.3"
 curl --retry 5 -sSfL 'https://raw.githubusercontent.com/bitrise-io/bitrise-build-cache-cli/main/install/installer.sh' | sh -s -- -b /tmp/bin -d $BITRISE_BUILD_CACHE_CLI_VERSION
 
 if [ "$collect_metrics" != "true" ] && [ "$collect_metrics" != "false" ]; then


### PR DESCRIPTION
Bump CLI version to v0.15.3
Update analytics with better task dependnecy graphs

### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a *PATCH* [version update](https://semver.org/)
