### PR TITLE
feat: also activate Gradle mirrors

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -76,4 +76,8 @@ if [ "$verbose" != "true" ] && [ "$verbose" != "false" ]; then
 fi
 
 # run the Bitrise Build Cache CLI
-/tmp/bin/bitrise-build-cache activate gradle --debug="$verbose" --cache --cache-push="$push" --cache-validation="$validation_level" --analytics="$collect_metrics" 
+/tmp/bin/bitrise-build-cache activate gradle --debug="$verbose" --cache --cache-push="$push" --cache-validation="$validation_level" --analytics="$collect_metrics"
+
+# Activate Bitrise repository mirrors for Gradle. Gracefully no-ops on
+# unsupported datacenters / when BITRISE_MAVENCENTRAL_PROXY_ENABLED is unset.
+/tmp/bin/bitrise-build-cache activate gradle-mirrors --debug="$verbose" || true


### PR DESCRIPTION
## Summary

Call `bitrise-build-cache activate gradle-mirrors` after the existing `activate gradle` invocation so workflows using this activator step automatically get Bitrise repository mirrors when the infrastructure is available. Mirrors gracefully no-op when:

- `BITRISE_MAVENCENTRAL_PROXY_ENABLED` is not set to `true`
- The current datacenter is not in the supported allowlist
- No mirror flags are selected (defaults to all known mirrors)

The trailing `|| true` is defence in depth so a transient mirror failure cannot fail the step.

Requires CLI v2.4.1 or later, which is already pinned.

## Test plan

- [ ] CI green
- [ ] Manual: run on a Bitrise build with `BITRISE_MAVENCENTRAL_PROXY_ENABLED=true` in a supported datacenter and verify `~/.gradle/init.d/bitrise-gradle-mirrors.init.gradle.kts` is written