### PR TITLE
feat: ACI-4936 drop redundant gradle-mirrors activation

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -77,7 +77,3 @@ fi
 
 # run the Bitrise Build Cache CLI
 /tmp/bin/bitrise-build-cache activate gradle --debug="$verbose" --cache --cache-push="$push" --cache-validation="$validation_level" --analytics="$collect_metrics"
-
-# Activate Bitrise repository mirrors for Gradle. Gracefully no-ops on
-# unsupported datacenters / when BITRISE_MAVENCENTRAL_PROXY_ENABLED is unset.
-/tmp/bin/bitrise-build-cache activate gradle-mirrors --debug="$verbose" || true


### PR DESCRIPTION
## Summary

- Drops the per-step `bitrise-build-cache activate gradle-mirrors` call.
- Mirror activation is now handled centrally by the VM-startup init script (build-prebooting-deployments [#1542](https://github.com/bitrise-io/build-prebooting-deployments/pull/1542) / [#1543](https://github.com/bitrise-io/build-prebooting-deployments/pull/1543)), so this call is redundant.
- The CLI is still downloaded and used to run `activate gradle`, so nothing else changes.

Ticket: [ACI-4936](https://bitrise.atlassian.net/browse/ACI-4936)

## Test plan

- [ ] CI passes
- [ ] E2E workflows still configure Gradle build cache correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-4936]: https://bitrise.atlassian.net/browse/ACI-4936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ