### PR TITLE
feat: Release new CLI v2.6.3

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -30,7 +30,7 @@ echo "Bitrise Build Cache is activated in this workspace, configuring the build 
 set -x
 
 # download the Bitrise Build Cache CLI
-export BITRISE_BUILD_CACHE_CLI_VERSION="v2.6.2"
+export BITRISE_BUILD_CACHE_CLI_VERSION="v2.6.3"
 curl --retry 5 -m 30 -sSfL 'https://raw.githubusercontent.com/bitrise-io/bitrise-build-cache-cli/main/install/installer.sh' | sh -s -- -b /tmp/bin -d $BITRISE_BUILD_CACHE_CLI_VERSION || true
 
 # Fall back to Artifact Registry if the download failed


### PR DESCRIPTION
This PR updates the Bitrise Build Cache CLI to v2.6.3.