### PR TITLE
tmp: build CLI from staging-app-endpoint branch for staging testing

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -29,33 +29,17 @@ echo "Bitrise Build Cache is activated in this workspace, configuring the build 
 
 set -x
 
-# download the Bitrise Build Cache CLI
-export BITRISE_BUILD_CACHE_CLI_VERSION="v2.8.1"
-curl --retry 5 -m 30 -sSfL 'https://raw.githubusercontent.com/bitrise-io/bitrise-build-cache-cli/main/install/installer.sh' | sh -s -- -b /tmp/bin -d $BITRISE_BUILD_CACHE_CLI_VERSION || true
-
-# Fall back to Artifact Registry if the download failed
-if [ ! -f /tmp/bin/bitrise-build-cache ]; then
-  echo "Failed to download Bitrise Build Cache CLI, trying Artifact Registry ..."
-
-  version="${BITRISE_BUILD_CACHE_CLI_VERSION#v}"
-  os=$(uname -s | tr '[:upper:]' '[:lower:]')
-  arch=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
-  package="bitrise-build-cache_${os}_${arch}.tar.gz"
-  filename="bitrise-build-cache_${version}_${os}_${arch}.tar.gz"
-
-  filepath="$package:$version:$filename"
-
-  echo "Downloading Bitrise Build Cache CLI from Artifact Registry: ${filepath}"
-
-  curl --retry 5 -m 60 -sSfL "https://artifactregistry.googleapis.com/download/v1/projects/ip-build-cache-prod/locations/us-central1/repositories/build-cache-cli-releases/files/${filepath}:download?alt=media" -o $package
-  tar -xzf "$package"
-  mkdir -p /tmp/bin
-  mv "bitrise-build-cache" /tmp/bin/bitrise-build-cache
-  rm -rf "$package"
-fi
+# TEMP: build the Bitrise Build Cache CLI from the staging-app-endpoint branch.
+# That branch points the CLI at app-staging.bitrise.io so CLI features
+# (e.g. benchmark phase) can be tested against staging. Do not merge.
+export BITRISE_BUILD_CACHE_CLI_BRANCH="staging-app-endpoint"
+mkdir -p /tmp/bin
+rm -rf /tmp/bitrise-build-cache-cli
+git clone --depth 1 --branch "$BITRISE_BUILD_CACHE_CLI_BRANCH" https://github.com/bitrise-io/bitrise-build-cache-cli.git /tmp/bitrise-build-cache-cli
+( cd /tmp/bitrise-build-cache-cli && go build -o /tmp/bin/bitrise-build-cache . )
 
 if [ ! -f /tmp/bin/bitrise-build-cache ]; then
-  echo "Failed to download Bitrise Build Cache CLI, exiting."
+  echo "Failed to build Bitrise Build Cache CLI, exiting."
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Makes the **Activate Gradle Remote Cache** step use the staging build of the Bitrise Build Cache CLI instead of a released version.

Replaces the released-CLI install path (`installer.sh` + Artifact Registry fallback, pinned to `v2.8.1`) with a `git clone --depth 1 --branch staging-app-endpoint` + `go build` of [`bitrise-build-cache-cli#347`](https://github.com/bitrise-io/bitrise-build-cache-cli/pull/347). That CLI branch points all `app.bitrise.io` calls at `app-staging.bitrise.io`, so CLI features (e.g. **benchmark phase**) can be exercised against staging.

## Notes

⚠️ **Not for merge.** Throwaway branch for staging testing. Requires Go on the stack to build the CLI from source. Pairs with the CLI's `staging-app-endpoint` branch (PR #347).

🤖 Generated with [Claude Code](https://claude.com/claude-code)